### PR TITLE
feat: fetch to ondemand delivery apps once every 3 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ Following use-cases are realized by connecting with FMS (fleet management servic
   - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine/) 
     - `/req_change_lock_flg` \[[go_interface_msgs/msg/ChangeLockFlg](https://github.com/eve-autonomy/go_interface_msgs/blob/main/msg/ChangeLockFlg.msg)\]:<br>Receives reservations for on-demand delivery.
   - from [on-demand delivery apps (user-defined)](#required-specifications-for-on-demand-delivery-apps)
-    - [`GET API`](#get-api--get-current-reservation-status):<br>Gets the current reservation status for on-demand delivery in the ego vehicle.
+    - [`GET API`](#get-api--get-current-reservation-status):<br>Gets the current reservation status for on-demand delivery in the ego vehicle in two cases.
+      - Every 3 seconds
+      - After successful PATCH requests
 - output
   - to [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine/)
     - `/api_vehicle_status` \[[go_interface_msgs/msg/VehicleStatus](https://github.com/eve-autonomy/go_interface_msgs/blob/main/msg/VehicleStatus.msg)\]:<br>The current reservation status for on-demand delivery in the ego vehicle.
   - to [on-demand delivery apps (user-defined)](#required-specifications-for-on-demand-delivery-apps)
-    - [`PATCH API`](#patch-api--update-reservation-status):<br>Updates the reservation status for on-demand delivery in the ego vehicle.
+    - [`PATCH API`](#patch-api--update-reservation-status):<br>Updates the reservation status for on-demand delivery in the ego vehicle. A PATCH request is sent when the vehicle reservation state is changes.
 
 ## Node Graph
 ![node graph](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/eve-autonomy/go_interface/main/docs/node_graph.pu)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This node integrates user-defined on-demand delivery apps with autonomous drivin
 
 Following use-cases are realized by connecting with FMS (fleet management service) providing by TIER IV, inc.
 
-- Switch operation mode between on-demand delivery and regular delivery.
+- Switch operation mode between on-demand delivery apps and regular delivery apps
 - Call an ego vehicle to a designated stop.
 - Send an ego vehicle to a designated stop.
 
@@ -14,16 +14,16 @@ Following use-cases are realized by connecting with FMS (fleet management servic
   - from [Web.Auto](https://tier4.jp/en/products/#webauto) (DevOps Platform provided by TIER IV)
     - `/webauto/vehicle_info` \[[std_msgs/msg/String](https://docs.ros2.org/foxy/api/std_msgs/msg/String.html)\]:<br>Gets unique ID of the ego vehicle managed by Web.Auto.
   - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine/) 
-    - `/req_change_lock_flg` \[[go_interface_msgs/msg/ChangeLockFlg](https://github.com/eve-autonomy/go_interface_msgs/blob/main/msg/ChangeLockFlg.msg)\]:<br>Receives reservations for on-demand delivery.
+    - `/req_change_lock_flg` \[[go_interface_msgs/msg/ChangeLockFlg](https://github.com/eve-autonomy/go_interface_msgs/blob/main/msg/ChangeLockFlg.msg)\]:<br>Receives reservations for on-demand delivery apps.
   - from [on-demand delivery apps (user-defined)](#required-specifications-for-on-demand-delivery-apps)
-    - [`GET API`](#get-api--get-current-reservation-status):<br>Gets the current reservation status for on-demand delivery in the ego vehicle in two cases.
+    - [`GET API`](#get-api--get-current-reservation-status):<br>Gets the current reservation status for on-demand delivery apps in the ego vehicle in two cases.
       - Every 3 seconds
       - After successful PATCH requests
 - output
   - to [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine/)
-    - `/api_vehicle_status` \[[go_interface_msgs/msg/VehicleStatus](https://github.com/eve-autonomy/go_interface_msgs/blob/main/msg/VehicleStatus.msg)\]:<br>The current reservation status for on-demand delivery in the ego vehicle.
+    - `/api_vehicle_status` \[[go_interface_msgs/msg/VehicleStatus](https://github.com/eve-autonomy/go_interface_msgs/blob/main/msg/VehicleStatus.msg)\]:<br>The current reservation status for on-demand delivery apps in the ego vehicle.
   - to [on-demand delivery apps (user-defined)](#required-specifications-for-on-demand-delivery-apps)
-    - [`PATCH API`](#patch-api--update-reservation-status):<br>Updates the reservation status for on-demand delivery in the ego vehicle. A PATCH request is sent when the vehicle reservation state is changes.
+    - [`PATCH API`](#patch-api--update-reservation-status):<br>Updates the reservation status for on-demand delivery apps in the ego vehicle. A PATCH request is sent when the vehicle reservation state is changes.
 
 ## Node Graph
 ![node graph](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/eve-autonomy/go_interface/main/docs/node_graph.pu)

--- a/go_interface/go_interface.py
+++ b/go_interface/go_interface.py
@@ -142,7 +142,7 @@ class GoInterface(Node):
                 "[go_interface] Failed to parse lock_flg retrieved from server.")
             return
         
-        self.get_vehicle_status()
+        self.fetch_from_ondemand_delivery_apps()
 
 
     def on_vehicle_info(self, vehicle_info):
@@ -167,9 +167,9 @@ class GoInterface(Node):
         if (self._vehicle_id==""):
             logger.error("[go_interface] _vehicle_id is unset.")
             return
-        self.get_vehicle_status()
+        self.fetch_from_ondemand_delivery_apps()
 
-    def get_vehicle_status(self):
+    def fetch_from_ondemand_delivery_apps(self):
         logger = self.get_logger()
 
         # Get vehicle-status from server via REST API

--- a/go_interface/go_interface.py
+++ b/go_interface/go_interface.py
@@ -159,21 +159,6 @@ class GoInterface(Node):
         self._vehicle_id = vehicle_id
         self._is_emergency = False
 
-    def retry_session(self, retries, session=None, backoff_factor=0.3):
-        session = session or requests.Session()
-        retry = Retry(
-            total=retries,
-            read=retries,
-            connect=retries,
-            backoff_factor=backoff_factor,
-            method_whitelist=False,
-        )
-        adapter = HTTPAdapter(max_retries=retry)
-        session.mount('http://', adapter)
-        session.mount('https://', adapter)
-        return session
-
-
     def output_timer(self):
         logger = self.get_logger()
         if (self._is_emergency):
@@ -249,6 +234,21 @@ class GoInterface(Node):
         vehicle_status.voice_flg = self._voice_flg
         vehicle_status.active_schedule_exists = self._active_schedule_exists
         self._vehicle_status_publisher.publish(vehicle_status)
+
+    def retry_session(self, retries, session=None, backoff_factor=0.3):
+        session = session or requests.Session()
+        retry = Retry(
+            total=retries,
+            read=retries,
+            connect=retries,
+            backoff_factor=backoff_factor,
+            method_whitelist=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        return session
+
 
 def main(args=None):
     rclpy.init(args=args)

--- a/go_interface/go_interface.py
+++ b/go_interface/go_interface.py
@@ -54,7 +54,7 @@ class GoInterface(Node):
 
         if not service_url.get_parameter_value().string_value \
                 or not access_token.get_parameter_value().string_value:
-            logger.info("[go_interface] Parameters not found.")
+            logger.error("[go_interface] Parameters not found.")
             return
 
         self._is_emergency = False
@@ -95,8 +95,6 @@ class GoInterface(Node):
 
     def on_change_lock_flg(self, change_lock_flg):
         logger = self.get_logger()
-        # info log
-        logger.info("[go_interface] on_change_lock_flg.")
         # Check if vehicle id has been updated
         if not self._vehicle_id:
             return
@@ -149,7 +147,6 @@ class GoInterface(Node):
 
     def on_vehicle_info(self, vehicle_info):
         logger = self.get_logger()
-        logger.info("[go_interface] on_vehicle_info.")
         # Parse data into json format
         json_str = json.loads(vehicle_info.data)
         # Get vehicle_id
@@ -179,18 +176,16 @@ class GoInterface(Node):
 
     def output_timer(self):
         logger = self.get_logger()
-        logger.info("[go_interface] output_timer.")
         if (self._is_emergency):
-            logger.info("[go_interface] is_emergency.")
+            logger.error("[go_interface] is_emergency.")
             return
         if (self._vehicle_id==""):
-            logger.info("[go_interface] _vehicle_id is unset.")
+            logger.error("[go_interface] _vehicle_id is unset.")
             return
         self.get_vehicle_status()
 
     def get_vehicle_status(self):
         logger = self.get_logger()
-        logger.info("[go_interface] get_vehicle_status.")
 
         # Get vehicle-status from server via REST API
         url = "{0}/api/vehicle_status?vehicle_id={1}".format(


### PR DESCRIPTION
## Description
専有ボタン押下時の反応速度を変えずに、ondemand delivery appsのコスト低減のために車両からondemand delivery appsへのアクセス頻度を1秒に1回から3秒に1回に変更するPR

- 修正前
  - ondemand delivery appsでスケジュール登録されたことの認識方法
    - 1秒に1回、車両の状態をondemand delivery appsからGETする。
  - 専有ボタンが操作されたことの認識方法  
    - 専有ボタンが操作されたら、車両の状態をPATCHでondemand delivery appsに送る。（車両の状態は1秒に1回のGETで更新する）

- 修正後
  - ondemand delivery appsでスケジュール登録されたことの認識方法
    - **3秒に1回**、車両の状態をondemand delivery appsからGETする。
  - 専有ボタンが操作されたことの認識方法
    - 専有ボタンが操作されたら、車両の状態をPATCHでondemand delivery appsに送り、成功したら**すぐに**車両の状態をondemand delivery appsからGETする。



詳細はRelated Links記載の仕様書に記載。

## 変更内容一覧

### New member methods
専有ボタン押下時の反応速度を変えずに、ondemand delivery appsへのアクセス頻度を変えるために以下のメンバ関数を追加
- output_timer
  - 3秒に1度実行されるコールバック関数。`get_vehicle_status`を実行
- get_vehicle_status
  - ondemand delivery appsにアクセスして車両情報を取得する関数。

### Modified member methods
- on_change_lock_flg
  - 専有ボタンが押下されたときにpublishされる `req_change_lock_flg`をsubscribeしたときに実行されるコールバック関数。コールバック関数ないでondemand delivery appsにアクセスする`get_vehicle_status`を実行
- on_vehicle_info
  - we.auto agentが1秒に1回車両情報を更新するためにpublishされる`/webauto/vehicle_info`をsubscribeしたときに実行されるコールバック関数。同時にondemand delivery appsにアクセスしないように変更

### New member variables
- _timer
  - `timer_period`間隔で`output_timer`を実行するタイマーオブジェクト
- _is_emergency
  - Vehicle IDが設定されていない場合にTrueになり、エラーログが出力される。

その他、解析をしやすくするためにロガーを追加。

## Related Links
仕様書 [TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/EVA/pages/3001876904/AEAP-864_)
Jira [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/AEAP-864)
ondemand delivery appsへのアクセス頻度確認試験 [TIER IV INTERNAL LINK](https://docs.google.com/spreadsheets/d/10S2hRXbxXa5KnCXNfZ-kRz6lsSenTrIPeEGFcKgGKjE/edit?gid=482937011#gid=482937011)

## Tests performed
本修正に関して以下の2点を確認した。

機能評価：車両からondemand delivery appsへのアクセス頻度が1秒に1回から3秒に1回になっている事
性能評価：占有ボタン押下時に占有LEDが更新完了するまでの時間が現状より悪化しない事

### 機能評価
   - ondemand delivery appsにアクセスするget_vehicle_status()が3秒に1回実行されていることをsyslogから確認。
       - get_vehicle_status()が実行されたことを示すロガーは本PRからは消去されているが、機能評価では本ブランチのinitial commitを使用しており、そのコミットには該当のロガーが含まれている。

### 性能評価
   - 占有ボタン押下時に占有LEDが更新完了するまでの時間が現状より悪化しない事を確認
     - 変更前：1.5秒以下
     - 変更後：1.5秒以下

## Regression test
ondemand delivery appsと通信する全ての機能を確認した。詳細はRelated Links記載のondemand delivery appsへのアクセス頻度確認試験を参照。