### PR TITLE
fix: change the deprecated parameter name in urllib3 v2.x

### DIFF
--- a/go_interface/go_interface.py
+++ b/go_interface/go_interface.py
@@ -242,7 +242,7 @@ class GoInterface(Node):
             read=retries,
             connect=retries,
             backoff_factor=backoff_factor,
-            method_whitelist=False,
+            allowed_methods=False,
         )
         adapter = HTTPAdapter(max_retries=retry)
         session.mount('http://', adapter)


### PR DESCRIPTION
## Description
`urllib3.util.retry.Retry`クラスのインスタンス生成の際に未定義のパラメータを渡してしまうことに起因したプロセス死亡が発生していた。

本PRではそのプロセス死を防止するものである。

### detail
v2.x系のurllib3では`method_whitelist`パラメータが廃止されている。そのため`urllib3.util.retry.Retry`クラスのインスタンスを生成しようとしたときにgo_interfaceのプロセスが死亡してしまい、車両がon-demand delivery appsと通信することができなくなってしまう。

本PRでは、下記の機能をサポートする。
- 専有ボタンを押してon-demand delivery appsと通信しようとしたときにプロセスが死亡するのを防止する。

### Error countermeasures
- `urllib3.util.retry.Retry`クラスのインスタンス生成で`method_whitelist`パラメータが渡されている部分を、互換性のある`allowed_methods`パラメータに変更する。

## Related Links
- Jira [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/AEAP-1996)
- on-demand delivery appsへのアクセス頻度確認試験 [TIER IV INTERNAL LINK](https://docs.google.com/spreadsheets/d/10S2hRXbxXa5KnCXNfZ-kRz6lsSenTrIPeEGFcKgGKjE/edit?gid=1453097464#gid=1453097464&range=G:H)
- `method_whitelist`の廃止に関するurllib3のドキュメンテーション[LINK](https://urllib3.readthedocs.io/en/1.26.8/reference/urllib3.util.html)

![image](https://github.com/user-attachments/assets/a922570e-82e7-4ccc-b0a5-c63c02e65b4c)

## Tests performed
本修正に関して以下の3点を確認した。

### 機能評価
- 占有ボタン押下時に占有LEDが正常に更新されること
  - 専有ボタンが点灯していない状態で、専有ボタンを1秒以上押下したときに専有LEDが**点灯**することを確認。
- 専有ボタンの操作がFMSに正常に反映されること
  - FMSで「配車指示」が「配車不可」の状態で専有ボタンを1秒以上押下すると「配車可」に変更されることを確認。
- on-demand delivery appsの全ての機能が正常に使えること

### Regression test
- on-demand delivery appsと通信する全ての機能を確認した。詳細はRelated Links記載のondemand delivery appsへのアクセス頻度確認試験を参照。